### PR TITLE
chore: Remove dependency on axios

### DIFF
--- a/r3f/package.json
+++ b/r3f/package.json
@@ -16,10 +16,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "dependencies": {
-    "axios": "^0.27.2",
-    "uuid": "^8.3.2"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@babel/core": "^7.14.6",
     "@babel/plugin-transform-runtime": "^7.14.5",

--- a/utils/networking.js
+++ b/utils/networking.js
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import { formats } from '../utils/formats.js';
 import { checkUserPlatform } from '../utils/helpers.js';
 import { parse as parseUUID } from 'uuid'
@@ -199,9 +198,10 @@ Check https://docs.zesty.xyz/guides/developers/ad-units for more information.`);
         if (currentTries[adUnitId] == retryCount) {
           try {
             const url = encodeURI(window.location.href).replace(/\/$/, ''); // If URL ends with a slash, remove it
-            const res = await axios.get(`${DB_ENDPOINT}/ad?ad_unit_id=${adUnitId}&url=${url}`);
-            if (res.data) {
-              resolve(res.data);
+            const res = await fetch(`${DB_ENDPOINT}/ad?ad_unit_id=${adUnitId}&url=${url}`);
+            if (res.status == 200) {
+              const data = await res.json();
+              resolve(data);
             } else {
               // No active campaign, just display default banner
               resolve(getDefaultBanner(format, style, shouldOverride, overrideEntry.format));
@@ -231,11 +231,13 @@ const sendOnLoadMetric = async (adUnitId, campaignId = null) => {
   const { platform, confidence } = await checkUserPlatform();
 
   try {
-    await axios.post(
-      BEACON_GRAPHQL_URI,
-      { query: `mutation { increment(eventType: visits, spaceId: \"${adUnitId}\", campaignId: \"${campaignId}\", platform: { name: ${platform}, confidence: ${confidence} }) { message } }` },
-      { headers: { 'Content-Type': 'application/json' } }
-    )
+    await fetch(BEACON_GRAPHQL_URI, {
+      method: 'POST',
+      body: JSON.stringify({ query: `mutation { increment(eventType: visits, spaceId: \"${adUnitId}\", campaignId: \"${campaignId}\", platform: { name: ${platform}, confidence: ${confidence} }) { message } }` }),
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    });
   } catch (e) {
     console.log("Failed to emit onload event", e.message)
   }
@@ -245,11 +247,11 @@ const sendOnClickMetric = async (adUnitId, campaignId = null) => {
   const { platform, confidence } = await checkUserPlatform();
 
   try {
-    await axios.post(
-      BEACON_GRAPHQL_URI,
-      { query: `mutation { increment(eventType: clicks, spaceId: \"${adUnitId}\", campaignId: \"${campaignId}\", platform: { name: ${platform}, confidence: ${confidence} }) { message } }` },
-      { headers: { 'Content-Type': 'application/json' } }
-    )
+    await fetch(BEACON_GRAPHQL_URI, {
+      method: 'POST',
+      body: JSON.stringify({ query: `mutation { increment(eventType: clicks, spaceId: \"${adUnitId}\", campaignId: \"${campaignId}\", platform: { name: ${platform}, confidence: ${confidence} }) { message } }` }),
+      headers: { 'Content-Type': 'application/json' }
+    });
   } catch (e) {
     console.log("Failed to emit onclick event", e.message)
   }
@@ -258,11 +260,11 @@ const sendOnClickMetric = async (adUnitId, campaignId = null) => {
 const analyticsSession = async (adUnitId, campaignId) => {
   const { platform, confidence } = await checkUserPlatform();
   try {
-    await axios.post(
-      BEACON_GRAPHQL_URI,
-      { query: `mutation { increment(eventType: session, spaceId: \"${adUnitId}\", campaignId: \"${campaignId}\", platform: { name: ${platform}, confidence: ${confidence} }) { message } }` },
-      { headers: { 'Content-Type': 'application/json' } }
-    )
+    await fetch(BEACON_GRAPHQL_URI, {
+      method: 'POST',
+      body: JSON.stringify({ query: `mutation { increment(eventType: session, spaceId: \"${adUnitId}\", campaignId: \"${campaignId}\", platform: { name: ${platform}, confidence: ${confidence} }) { message } }` }),
+      headers: { 'Content-Type': 'application/json' }
+    });
   } catch (e) {
     console.log(`Failed to emit session analytics`, e.message)
   }

--- a/utils/package.json
+++ b/utils/package.json
@@ -12,7 +12,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "axios": "^0.27.2",
     "sig-beacon": "^0.0.14",
     "three": "^0.166.1",
     "uuid": "^8.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1886,25 +1886,12 @@ arraybuffer.prototype.slice@^1.0.3:
     is-array-buffer "^3.0.4"
     is-shared-array-buffer "^1.0.2"
 
-asynckit@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
-  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
-
 available-typed-arrays@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz#a5cc375d6a03c2efc87a553f3e0b1522def14846"
   integrity sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==
   dependencies:
     possible-typed-array-names "^1.0.0"
-
-axios@^0.27.2:
-  version "0.27.2"
-  resolved "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz"
-  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
-  dependencies:
-    follow-redirects "^1.14.9"
-    form-data "^4.0.0"
 
 babel-loader@^8.2.5:
   version "8.3.0"
@@ -2135,13 +2122,6 @@ colorette@^2.0.10, colorette@^2.0.14:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
 
-combined-stream@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz"
-  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
-  dependencies:
-    delayed-stream "~1.0.0"
-
 commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz"
@@ -2334,11 +2314,6 @@ define-properties@^1.2.0, define-properties@^1.2.1:
     define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
-
-delayed-stream@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 depd@2.0.0:
   version "2.0.0"
@@ -2978,7 +2953,7 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.1.tgz#21db470729a6734d4997002f439cb308987f567a"
   integrity sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.9:
+follow-redirects@^1.0.0:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
@@ -2989,15 +2964,6 @@ for-each@^0.3.3:
   integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
   dependencies:
     is-callable "^1.1.3"
-
-form-data@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz"
-  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    mime-types "^2.1.12"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -3822,7 +3788,7 @@ mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12, mime-types@^2.1.27, mime-types@^2.1.31, mime-types@~2.1.17, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.27, mime-types@^2.1.31, mime-types@~2.1.17, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==


### PR DESCRIPTION
Getting ready to PR a new integration with Playcanvas, but wanted to get this in beforehand. For the Playcanvas Editor we'll need to make a bundled output file that the user can drop into their project to get a ZestyBanner component. In the interest of reducing the final bundle size, I went through and found that we're currently only using axios to make some basic GET and POST requests in `networking.js`, which can pretty trivially be replaced by just using `fetch` instead. 