### PR TITLE
Export babylonjs SDK via UMD wrapper + add @zestyxyz/beacon

### DIFF
--- a/babylonjs/webpack.config.js
+++ b/babylonjs/webpack.config.js
@@ -6,7 +6,13 @@ module.exports = {
     },
     output: {
         filename: '[name].js',
-        path: path.resolve(__dirname, 'dist')
+        path: path.resolve(__dirname, 'dist'),
+        library: {
+            name: 'ZestyBanner',
+            type: 'umd',
+            export: 'default',
+        },
+        globalObject: 'this',
     },
     devServer: {
         contentBase: __dirname,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1683,6 +1683,11 @@
   resolved "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@zestyxyz/beacon@latest":
+  version "0.0.16"
+  resolved "https://registry.yarnpkg.com/@zestyxyz/beacon/-/beacon-0.0.16.tgz#7c01637898e5eae315ecff017b600236072368d6"
+  integrity sha512-pJcZODHxM6gbVAVoixfD4APd3ZxNw4NXV6ZVKmjS1UedhEWNMC7RJQpQH+N9pEIHdTk23wY2ORcyzuxUkuA9kw==
+
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz"
@@ -4628,11 +4633,6 @@ side-channel@^1.0.6:
     es-errors "^1.3.0"
     get-intrinsic "^1.2.4"
     object-inspect "^1.13.1"
-
-sig-beacon@^0.0.14:
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/sig-beacon/-/sig-beacon-0.0.14.tgz#c2434472a64cfb91c4c46cd50a131565ea81c678"
-  integrity sha512-BQo7GTCdbA+SAKBC3JcCsWNl/0mcr3aPUZInPZ9Vj+4LnSLYTWL+mWLf81/4AYh+NDl9Rf4WZVvaYR1ghuwsoA==
 
 signal-exit@^3.0.3:
   version "3.0.7"


### PR DESCRIPTION
The @zestyxyz/babylon-sdk wasn't exporting anything. Needed to also add the `@zestyxyz/beacon` as workspace dep.
