### PR TITLE
utils: update api.zesty.market to api.borellion.com

### DIFF
--- a/unity/Assets/ZestySDK/Scripts/Internal/Utils/Constants.cs
+++ b/unity/Assets/ZestySDK/Scripts/Internal/Utils/Constants.cs
@@ -4,7 +4,7 @@
         public const string RELAY_URL = "https://relay.borellion.com";
         public const string BEACON_URL = "https://beacon.zesty.market/api/v1";
         public const string BEACON2_URL = "https://beacon2.zesty.market/zgraphql";
-        public const string AD_SERVER_URL = "https://api.zesty.market/api";
+        public const string AD_SERVER_URL = "https://api.borellion.com/api";
         public const string CDN_URL = "https://cdn.zesty.xyz";
         public const bool PREBID = true;
         public const int MAX_PREBID_RETRIES = 4;

--- a/utils/networking.js
+++ b/utils/networking.js
@@ -157,8 +157,7 @@ const getDefaultBanner = (format, style = 'standard', shouldOverride = false, ov
 }
 
 const getSampleBanner = (format) => {
-  const ENDPOINT = isStaging ? STAGING_DB_ENDPOINT : DB_ENDPOINT;
-  return { Ads: [{ asset_url: `${ENDPOINT}/ad/sample?format=${format}&timestamp=${Date.now()}`, cta_url: DEFAULT_CTA_URL }], CampaignId: DEFAULT_CAMPAIGN_ID }
+  return { Ads: [{ asset_url: `${DB_ENDPOINT}/ad/sample?format=${format}&timestamp=${Date.now()}`, cta_url: DEFAULT_CTA_URL }], CampaignId: DEFAULT_CAMPAIGN_ID }
 }
 
 const fetchFromZestyAPI = async (adUnitId, format, style, shouldOverride, overrideEntry, customDefaultImage = null, customDefaultCtaUrl = null) => {

--- a/utils/networking.js
+++ b/utils/networking.js
@@ -8,8 +8,7 @@ const BEACON_GRAPHQL_URI = 'https://beacon2.zesty.market/zgraphql'
 const DEFAULT_CTA_URL = 'https://relay.borellion.com/';
 const DEFAULT_CAMPAIGN_ID = 'DefaultCampaign';
 
-const DB_ENDPOINT = 'https://api.zesty.market/api';
-const STAGING_DB_ENDPOINT = 'https://api-staging.zesty.market/api';
+const DB_ENDPOINT = 'https://api.borellion.com/api';
 
 // Prebid variables
 const AD_REFRESH_INTERVAL = 30000;


### PR DESCRIPTION
Also remove staging API, because we don't have one.