### PR TITLE
Fix importing multiple networking versions

### DIFF
--- a/aframe/package.json
+++ b/aframe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@borellion/aframe-sdk",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "This is the A-Frame SDK for Borellion Banner integration.",
   "main": "dist/borellion-aframe-sdk.js",
   "files": [

--- a/babylonjs/package.json
+++ b/babylonjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@borellion/babylonjs-sdk",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "This is the babylon.js SDK for Borellion Banner integration.",
   "main": "dist/borellion-babylonjs-sdk.js",
   "files": [

--- a/playcanvas/package.json
+++ b/playcanvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@borellion/playcanvas-sdk",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "PlayCanvas SDK for Borellion Banner integration.",
   "main": "dist/borellion-playcanvas-sdk.js",
   "exports": {

--- a/playcanvas/package.json
+++ b/playcanvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@borellion/playcanvas-sdk",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "PlayCanvas SDK for Borellion Banner integration.",
   "main": "dist/borellion-playcanvas-sdk.js",
   "exports": {

--- a/r3f/package.json
+++ b/r3f/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@borellion/r3f-sdk",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "This is the react-three-fiber SDK for Borellion Banner integration.",
   "main": "dist/borellion-r3f-sdk.js",
   "exports": {

--- a/tests/babylonjs/index.html
+++ b/tests/babylonjs/index.html
@@ -2,8 +2,8 @@
 <html>
 
 <head>
-    <script src="https://cdn.babylonjs.com/babylon.js"></script>
-    <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
+    <script src="https://cdn.babylonjs.com/v5.57.1/babylon.js"></script>
+    <script src="https://cdn.babylonjs.com/v5.57.1/loaders/babylonjs.loaders.min.js"></script>
     <script src="../../babylonjs/dist/borellion-babylonjs-sdk.js"></script>
     <title>Babylon.js Test</title>
     <style>

--- a/tests/wonderland.test.mjs
+++ b/tests/wonderland.test.mjs
@@ -119,6 +119,46 @@ test.describe('Prebid @skip', () => {
   });
 });
 
+test.describe('Beacon reliability @skip', () => {
+  // Regression test for a bug where sendOnLoadMetric only fired from inside
+  // the texture-load success path. A blocked/broken/CORS-failing creative
+  // image meant the promise never resolved (and had no .catch()), so the
+  // "visits" beacon silently and permanently never fired for that ad unit -
+  // even though a real ad had already been served. See: Boulderworld
+  // (dmnshd.gg) integration, which served real paid campaigns for 8 days
+  // while beacon2.zesty.market recorded zero visits/clicks the whole time.
+  test('sendOnLoadMetric still fires when the banner creative image fails to load', async ({ page }) => {
+    const incrementCalls = [];
+    await page.route('**/zgraphql', async (route) => {
+      const postData = route.request().postData() || '';
+      if (postData.includes('mutation { increment')) {
+        incrementCalls.push(postData);
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: '{"data":{"increment":{"message":"ok"}}}',
+      });
+    });
+
+    // Serve a creative pointing at an image URL that will 404, simulating a
+    // blocked/broken/CORS-failing ad image - the real-world failure mode
+    // that triggered this bug.
+    await injectIFrame(page, EXAMPLE_URL, 'http://localhost:8080/tests/res/does-not-exist.jpg', MEDIUM_RECTANGLE_ID);
+
+    // Give the (failing) texture load time to reject and settle.
+    await page.waitForTimeout(5000);
+
+    // Sanity check: this is genuinely exercising the failure path - the
+    // banner should never have successfully applied a texture.
+    const banner = await page.evaluate(() => window.testBanners[0].banner);
+    expect(banner).toBeFalsy();
+
+    // The actual regression check: the impression must still be recorded.
+    expect(incrementCalls.some(c => c.includes('eventType: visits'))).toBe(true);
+  });
+});
+
 test.describe('Modal @skip', () => {
   test('An ad modal is created when the modal trigger event is fired', async ({ page }) => {
     await injectIFrame(page, EXAMPLE_URL, EXAMPLE_IMAGE_MEDIUM_RECTANGLE, MEDIUM_RECTANGLE_ID);

--- a/threejs/package.json
+++ b/threejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@borellion/threejs-sdk",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "This is the three.js SDK for Borellion Banner integration.",
   "main": "dist/borellion-threejs-sdk.js",
   "files": [

--- a/threlte/package.json
+++ b/threlte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@borellion/threlte-sdk",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Threlte SDK for Borellion Banner integration.",
   "type": "module",
   "main": "dist/borellion-threlte-sdk.js",

--- a/utils/networking.js
+++ b/utils/networking.js
@@ -25,9 +25,16 @@ const intervals = {};
 let divCount = 0;
 
 // Instantiate the beacon prototype as an import side-effect for now
-// just so we don't need to modify all the other SDKs
-const beacon = new Beacon('https://relay.borellion.com');
-beacon.signal();
+// just so we don't need to modify all the other SDKs.
+// Guarded because this module gets bundled twice in some SDKs (e.g. the
+// Wonderland SDK's dynamicNetworking option dynamically re-imports a
+// separately-published copy of this same file) -- without this check that
+// would construct and signal a second, redundant Beacon on the same page.
+if (typeof window !== 'undefined' && !window.__borellionNetworkingBeaconInit) {
+  window.__borellionNetworkingBeaconInit = true;
+  const beacon = new Beacon('https://relay.borellion.com');
+  beacon.signal();
+}
 
 // Check if the Zesty debug param is present
 const Params = URLSearchParams ? URLSearchParams : Map; // Shadowing with Map in case unavailable

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@borellion/web-sdk",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Web SDK for Borellion Banner integration into an HTML page via WebComponents.",
   "main": "dist/borellion-web-sdk.js",
   "files": [

--- a/wonderland/package.json
+++ b/wonderland/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@borellion/wonderland-sdk",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Wonderland Engine SDK for Borellion Banner integration.",
   "main": "dist/borellion-wonderland-sdk.js",
   "exports": {

--- a/wonderland/src/index.js
+++ b/wonderland/src/index.js
@@ -196,6 +196,17 @@ export class Borellion extends Component {
         onFill: (activeCampaign) => {
           const { asset_url: image, cta_url: url } = activeCampaign.Ads[0];
 
+          // Record the impression as soon as an ad has been served, rather than
+          // gating it behind texture load succeeding: a blocked/broken image
+          // shouldn't silently and permanently prevent this ad unit from ever
+          // reporting a visit again (sdkLoaded is set once, module-wide).
+          if (this.beacon && !sdkLoaded) {
+            this.dynamicNetworking && this.dynamicNetworkFunctions?.sendOnLoadMetric ?
+              this.dynamicNetworkFunctions.sendOnLoadMetric(this.adUnit, activeCampaign.CampaignId) :
+              sendOnLoadMetric(this.adUnit, activeCampaign.CampaignId);
+            sdkLoaded = true;
+          }
+
           // Free old banner images from the texture atlas
           if (this.mesh.material?.flatTexture != null) {
             this.mesh.material.flatTexture.destroy();
@@ -280,12 +291,6 @@ export class Borellion extends Component {
               this.mesh.material[this.textureProperty] = banner.texture;
               this.mesh.material.alphaMaskTexture = banner.texture;
             }
-            if (this.beacon && !sdkLoaded) {
-              this.dynamicNetworking && this.dynamicNetworkFunctions?.sendOnLoadMetric ?
-                this.dynamicNetworkFunctions.sendOnLoadMetric(this.adUnit, this.banner.campaignId) :
-                sendOnLoadMetric(this.adUnit, this.banner.campaignId);
-              sdkLoaded = true;
-            }
           };
 
           if (image.includes('canvas://')) {
@@ -296,6 +301,8 @@ export class Borellion extends Component {
           } else {
             this.engine.textures.load(image, '').then(texture => {
               applyBanner({ texture, imageSrc: image, url, campaignId: activeCampaign.CampaignId });
+            }).catch(err => {
+              console.error("'borellion' failed to load banner texture:", err);
             });
           }
         }


### PR DESCRIPTION
The SDK loading should trigger an SDK load metric, and any other metric for an impression should be recorded through another way. This way, we still fire an SDK load even in cases where the developer may have decided to override the default banner with their own, after the SDK loaded.

Further thinking needs to go into separating out impressions from pure SDK loads, at the texture level. We may need to track metrics on when the Borellion SDK fails to load the banner texture.